### PR TITLE
🪲 [Fix]: Fix linter settings and docs

### DIFF
--- a/.github/PSModule.yml
+++ b/.github/PSModule.yml
@@ -19,3 +19,12 @@ Test:
 # Build:
 #   Docs:
 #     Skip: true
+Linter:
+  env:
+    VALIDATE_BIOME_FORMAT: false
+    VALIDATE_BIOME_LINT: false
+    VALIDATE_GITHUB_ACTIONS_ZIZMOR: false
+    VALIDATE_JSCPD: false
+    VALIDATE_JSON_PRETTIER: false
+    VALIDATE_MARKDOWN_PRETTIER: false
+    VALIDATE_YAML_PRETTIER: false

--- a/.github/PSModule.yml
+++ b/.github/PSModule.yml
@@ -19,3 +19,13 @@ Test:
 # Build:
 #   Docs:
 #     Skip: true
+
+Linter:
+  env:
+    VALIDATE_BIOME_FORMAT: false
+    VALIDATE_BIOME_LINT: false
+    VALIDATE_GITHUB_ACTIONS_ZIZMOR: false
+    VALIDATE_JSCPD: false
+    VALIDATE_JSON_PRETTIER: false
+    VALIDATE_MARKDOWN_PRETTIER: false
+    VALIDATE_YAML_PRETTIER: false

--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -8,18 +8,19 @@
 ###############
 # Rules by id #
 ###############
-MD004: false                  # Unordered list style
+MD004: false # Unordered list style
 MD007:
-  indent: 2                   # Unordered list indentation
+  indent: 2 # Unordered list indentation
 MD013:
-  line_length: 808            # Line length
+  line_length: 808 # Line length
+MD024: false # no-duplicate-heading, INPUTS and OUTPUTS _can_ be the same item
 MD026:
-  punctuation: ".,;:!。，；:"  # List of not allowed
-MD029: false                  # Ordered list item prefix
-MD033: false                  # Allow inline HTML
-MD036: false                  # Emphasis used instead of a heading
+  punctuation: '.,;:!。，；:' # List of not allowed
+MD029: false # Ordered list item prefix
+MD033: false # Allow inline HTML
+MD036: false # Emphasis used instead of a heading
 
 #################
 # Rules by tags #
 #################
-blank_lines: false  # Error on blank lines
+blank_lines: false # Error on blank lines

--- a/src/functions/public/Realm/Get-WoWRealm.ps1
+++ b/src/functions/public/Realm/Get-WoWRealm.ps1
@@ -16,7 +16,7 @@ function Get-WoWRealm {
     General notes
     #>
     [CmdletBinding()]
-    [OutputType([Addon[]])]
+    [OutputType([Realm[]])]
     param(
         # The name of the realm to get
         [Parameter(Mandatory)]

--- a/src/functions/public/Realm/Get-WoWRealm.ps1
+++ b/src/functions/public/Realm/Get-WoWRealm.ps1
@@ -24,3 +24,4 @@ function Get-WoWRealm {
     )
     return $Script:WoW_Realms | Where-Object Name -Match $Name
 }
+#SkipTest:FunctionTest:Difficult to test due to the nature of the function.

--- a/src/functions/public/Realm/Get-WoWRealm.ps1
+++ b/src/functions/public/Realm/Get-WoWRealm.ps1
@@ -18,9 +18,9 @@ function Get-WoWRealm {
     [CmdletBinding()]
     [OutputType([Addon[]])]
     param(
-        [String]
-        $Name
+        # The name of the realm to get
+        [Parameter(Mandatory)]
+        [String] $Name
     )
     return $Script:WoW_Realms | Where-Object Name -Match $Name
 }
-#SkipTest:FunctionTest:Difficult to test due to the nature of the function.

--- a/tests/WoW.Tests.ps1
+++ b/tests/WoW.Tests.ps1
@@ -2,4 +2,7 @@
 param()
 
 Describe 'WoW' {
+    It 'Module is loaded' {
+        Get-Module -Name WoW | Should -Not -Be $null
+    }
 }


### PR DESCRIPTION
This pull request makes minor updates to the repository's configuration files, focusing on linting and markdown linting behavior.

Linting configuration updates:

* Added a `Linter` section to the `.github/PSModule.yml` file, explicitly disabling several validation checks such as Biome format/lint, GitHub Actions Zizmor, JSCPD, and various Prettier validations.

Markdown linting rule adjustments:

* Updated `.github/linters/.markdown-lint.yml` to:
  * Disable the `MD024` rule (no duplicate headings), allowing INPUTS and OUTPUTS to be repeated.
  * Fix a minor formatting issue in the `MD026` rule's punctuation list.